### PR TITLE
Fix for loader.js issue

### DIFF
--- a/adler32cs.js
+++ b/adler32cs.js
@@ -9,7 +9,7 @@ void function(global, callback) {
 	if (typeof module === 'object') {
 		module.exports = callback();
 	} else if (typeof define === 'function') {
-		define(callback);
+		define('adler32cs', [], callback);
 	} else {
 		global.adler32cs = callback();
 	}


### PR DESCRIPTION
When loader.js is used define must be provided with an id and the dependencies array or an exception is thrown.

Fix: Added id and an empty dependency array for require() call.

More details about the issue:
https://github.com/MrRio/jsPDF/issues/1317
https://github.com/MrRio/jsPDF/issues/1163
https://github.com/MrRio/jsPDF/issues/905